### PR TITLE
Manage oslo_middleware/max_request_body_size

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -571,6 +571,10 @@
 #   HTTPProxyToWSGI middleware.
 #   Defaults to $::os_service_default.
 #
+# [*max_request_body_size*]
+#   (Optional) Set max request body size
+#   Defaults to $::os_service_default.
+#
 # [*purge_config*]
 #   (optional) Whether to set only the specified config options
 #   in the keystone config.
@@ -754,6 +758,7 @@ class keystone(
   $keystone_group                       = $::keystone::params::keystone_group,
   $manage_policyrcd                     = false,
   $enable_proxy_headers_parsing         = $::os_service_default,
+  $max_request_body_size                = $::os_service_default,
   $purge_config                         = false,
   # DEPRECATED PARAMETERS
   $admin_workers                        = max($::processorcount, 2),
@@ -950,6 +955,7 @@ We have enabled caching as a backwards compatibility that will be removed in the
 
   oslo::middleware { 'keystone_config':
     enable_proxy_headers_parsing => $enable_proxy_headers_parsing,
+    max_request_body_size        => $max_request_body_size;
   }
 
   # configure based on the catalog backend


### PR DESCRIPTION
So that we can increase it from the default 114688

Useful in case for example the OS-Federation mapping is too large.

If this limit is breached keystone will return a 413 Entity Too Large
and not log anything to keystone.log.

 - #CCCP-2783

Branch off of newton-eol