### PR TITLE
Install python2-keystoneclient instead

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 #
 class keystone::params {
   include ::openstacklib::defaults
-  $client_package_name = 'python-keystoneclient'
+  $client_package_name = 'python2-keystoneclient'
   $keystone_user       = 'keystone'
   $keystone_group      = 'keystone'
   $keystone_wsgi_admin_script_path  = '/usr/bin/keystone-wsgi-admin'


### PR DESCRIPTION
Puppet4 tries to do a "yum list python-keystoneclient" which fails. yum install
python-keystoneclient works though (and it finds the
python2-keystoneclient)