### PR TITLE
Revert "Install python2-keystoneclient instead"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 #
 class keystone::params {
   include ::openstacklib::defaults
-  $client_package_name = 'python2-keystoneclient'
+  $client_package_name = 'python-keystoneclient'
   $keystone_user       = 'keystone'
   $keystone_group      = 'keystone'
   $keystone_wsgi_admin_script_path  = '/usr/bin/keystone-wsgi-admin'


### PR DESCRIPTION
Reverts CSCfi/puppet-keystone#2

Instead of this - we can in our site.pp stop setting "allow_virtual_packages = false"